### PR TITLE
fix(elite-card-creator): correct base path for deployment

### DIFF
--- a/elite-card-creator/index.html
+++ b/elite-card-creator/index.html
@@ -84,7 +84,7 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
+<link rel="stylesheet" href="./index.css">
 </head>
 <body>
     <div id="root"></div>

--- a/elite-card-creator/vite.config.ts
+++ b/elite-card-creator/vite.config.ts
@@ -19,6 +19,6 @@ export default defineConfig(({ mode }) => {
         '@': path.resolve(__dirname, '.'),
       }
     },
-    base: '/games/elite-card-creator/',
+    base: '/elite-card-creator/',
   };
 });


### PR DESCRIPTION
Changes the base path from `/games/elite-card-creator/` to `/elite-card-creator/` to match the hosting location on jared.rosen.systems. Also fixes the index.css reference to use a relative path.